### PR TITLE
removed --save-scmversion

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -39,10 +39,10 @@ export KBUILD_BUILD_TIMESTAMP="$(date -Ru${SOURCE_DATE_EPOCH:+d @$SOURCE_DATE_EP
 prepare() {
   cd $_srcname
 
-  echo "Setting version..."
-  scripts/setlocalversion --save-scmversion
-  echo "-$pkgrel" > localversion.10-pkgrel
-  echo "${pkgbase#linux}" > localversion.20-pkgname
+  #echo "Setting version..."
+  #scripts/setlocalversion --save-scmversion
+  #echo "-$pkgrel" > localversion.10-pkgrel
+  #echo "${pkgbase#linux}" > localversion.20-pkgname
 
   local src
   for src in "${source[@]}"; do


### PR DESCRIPTION
I don't know if there is a better solution but since support for this option is removed `--save-scmversion` making the aur package failed, I fixed that by comment these lines.